### PR TITLE
Fix wrong calculation of sets when it contains a product with zero quantity

### DIFF
--- a/src/Spryker/Zed/ProductBundle/Business/ProductBundle/Stock/ProductBundleStockWriter.php
+++ b/src/Spryker/Zed/ProductBundle/Business/ProductBundle/Stock/ProductBundleStockWriter.php
@@ -201,7 +201,7 @@ class ProductBundleStockWriter implements ProductBundleStockWriterInterface
     {
         $bundleTotalStockPerWarehouse = [];
         foreach ($bundledItemStock as $idStock => $warehouseStock) {
-            $bundleStock = new Decimal(0);
+            $bundleStock = new Decimal(PHP_INT_MAX);
             $isAllNeverOutOfStock = true;
             foreach ($warehouseStock as $idProduct => $productStockQuantity) {
                 $bundleItemQuantity = $bundledItemQuantity[$idProduct];
@@ -219,7 +219,7 @@ class ProductBundleStockWriter implements ProductBundleStockWriterInterface
             }
 
             $bundleTotalStockPerWarehouse[$idStock] = [
-                static::QUANTITY => $bundleStock->floor(),
+                static::QUANTITY => $bundleStock->floor()->toInt() == PHP_INT_MAX ? (new Decimal(0))->floor() : $bundleStock->floor(),
                 static::IS_NEVER_OUT_OF_STOCK => $isAllNeverOutOfStock,
             ];
         }
@@ -236,7 +236,7 @@ class ProductBundleStockWriter implements ProductBundleStockWriterInterface
      */
     protected function isCurrentStockIsLowestWithingBundle(Decimal $bundleStock, Decimal $itemStock, bool $isNeverOutOfStock): bool
     {
-        if (($bundleStock->greaterThan($itemStock) || $bundleStock->isZero()) && !$isNeverOutOfStock) {
+        if (($bundleStock->greaterThan($itemStock)) && !$isNeverOutOfStock) {
             return true;
         }
 


### PR DESCRIPTION
## PR Description

Here we had an issue with product set stock amount when one of the set products has lowest value 0.
Then because of the bug it has been setting it to the first non-negative lowest value which is incorrect.
Usually when you want to find the minimum, you want to have an assumption that the minimum is highest integer (because every other found will be less than it) Spryker went with the assumption that on the first run quantity is zero hence what caused the bug.

The change is subtle
$bundleStock = new Decimal(PHP_INT_MAX);


I've managed to reproduced it in the demoshop
![Screenshot 2022-07-28 at 13 01 23](https://user-images.githubusercontent.com/25713813/181493496-a6c2066d-7ec3-4f5a-ba23-fa22caef8a29.png)

As soon as you have product in bundle that is not marked as never out of stock and you set it to zero, the calculation becomes wrong
![Screenshot 2022-07-28 at 13 02 33](https://user-images.githubusercontent.com/25713813/181493853-7e6df228-127d-4f44-8712-4232e105b4e3.png)

